### PR TITLE
Don’t show comments from .gitignore

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -161,7 +161,9 @@ exports.start = function(config) {
                 logger.info('Watching: ' + dir);
             });
 
-            eventArgs.ignorePatterns.forEach(function(pattern) {
+            eventArgs.ignorePatterns.filter(function(pattern) {
+                return ! /^[#;]/.test(pattern); // don't show comments from .gitignore
+            }).forEach(function(pattern) {
                 logger.info('Ignore rule: ' + pattern);
             });
         })


### PR DESCRIPTION
If a `.gitignore` file has comment lines, `browser-refresh` will announce them as patterns, like so:

```sh
$ browser-refresh index.js
[browser-refresh] Watching: /Users/me/git/project
[browser-refresh] Ignore rule: #### MacOS ####
[browser-refresh] Ignore rule: .DS_Store
[browser-refresh] Ignore rule: .AppleDouble
[browser-refresh] Ignore rule: .LSOverride
[browser-refresh] Ignore rule: # Icon must end with two \r
[browser-refresh] Ignore rule: Icon
[browser-refresh] Ignore rule: # Thumbnails
[browser-refresh] Ignore rule: ._*
[browser-refresh] Ignore rule: #### Node.JS ####
```

I’m unsure this is the place to filter them out, though — _technically_ a filename can start with the gitconfig comment characters (`#` and `;`). I couldn’t find the code that parses out patterns from `.gitignore`, but if you show me where I’ll filter there instead!